### PR TITLE
Update helper_pathway.R

### DIFF
--- a/R/helper_pathway.R
+++ b/R/helper_pathway.R
@@ -51,7 +51,7 @@ helper_pathway_gsva <- function(alldata, method = "aucell", geneset, ncores = 1)
 
             for (i in c(2:length(index))) {
                 start <- index[i - 1]
-                finish <- index[i] - 1
+                finish <- ifelse(i == length(index), index[i], index[i] - 1)
 
                 message("calculating ", start, " to ", finish, " cells")
                 thesecell <- as.matrix(alldata$data[, start:finish])


### PR DESCRIPTION
When greater than 30000 cells, the final set upper bound index is incorrectly set to be 1 less than the true length. This causes an index mismatch.